### PR TITLE
Patch for BATCHADM-141

### DIFF
--- a/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/servlet/resources/resources-context.xml
+++ b/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/servlet/resources/resources-context.xml
@@ -115,7 +115,7 @@
 				<prop key="servletPath">#{resourceService.servletPath}</prop>
 			</props>
 		</property>
-		<property name="contentType" value="text/plain" />
+		<property name="contentType" value="application/json" />
 	</bean>
 
 	<bean id="home" parent="standard" />


### PR DESCRIPTION
Spring Batch Admin JSON API sets content type to text/plain on the response. Setting it to application/json as it makes most sense for the response content type.
