### PR TITLE
Using JMX support in the virgo 3.5 osgi container

### DIFF
--- a/spring-batch-admin-manager/template.mf
+++ b/spring-batch-admin-manager/template.mf
@@ -26,3 +26,5 @@ Import-Template:
  javax.sql;version="0",
  javax.servlet.*;version="0";resolution:=optional,
  org.w3c.dom.*;version="0"
+Import-Package: 
+ org.springframework.jmx.support;version="[3.0.0, 4.0.0)"


### PR DESCRIPTION
Hi Chaps,

It would be good if you could accept this minor change. Without adding this package you get java.lang.ClassNotFoundException for 'org.springframework.jmx.support.MetricType' as soon as you
start to use JMX for monitoring jobs.

Any bundle you build that depends on spring-batch-admin-manager fails to deploy. The change I have commited makes this work on Virgo 3.5

Cheers,

Ron
