### PR TITLE
BATCHADM-152: Added Batch Job Execution Exit Message on Job Execution Details page

### DIFF
--- a/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/execution.ftl
+++ b/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/execution.ftl
@@ -87,11 +87,11 @@
 				<td>Exit Code</td>
 				<td>${jobExecutionInfo.jobExecution.exitStatus.exitCode}</td>
 			</tr>
-			<tr class="name-sublevel1-odd">
+			<tr class="name-sublevel1-even">
 				<td>Exit Message</td>
 				<td>${jobExecutionInfo.jobExecution.exitStatus.exitDescription}</td>
 			</tr>
-			<tr class="name-sublevel1-even">
+			<tr class="name-sublevel1-odd">
 				<#assign url><@spring.url relativeUrl="${servletPath}/jobs/executions/${jobExecutionInfo.id?c}/steps"/></#assign>
 				<td>Step Executions Count</td>
 				<td><a href="${url}"/>${jobExecutionInfo.stepExecutionCount}</a></td>


### PR DESCRIPTION
Fix for this feature request: https://jira.springsource.org/browse/BATCHADM-152

This is a useful field for showing a simple log message regarding the batch's final progress, such as "Imported 100 records"

![BATCHADM-152](https://f.cloud.github.com/assets/327741/235630/d8c6c666-87b3-11e2-886a-1ab53a15708e.png)
