### PR TITLE
Fixing sort key setting

### DIFF
--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDao.java
@@ -129,7 +129,7 @@ public class JdbcSearchableJobExecutionDao extends JdbcJobExecutionDao implement
 		factory.setFromClause(getQuery(fromClause));
 		factory.setSelectClause(FIELDS);
 		Map<String, Order> sortKeys = new HashMap<String, Order>();
-		sortKeys.put("E.JOB_EXECUTION_ID", Order.DESCENDING);
+		sortKeys.put("JOB_EXECUTION_ID", Order.DESCENDING);
 		factory.setSortKeys(sortKeys);
 		whereClause = "E.JOB_INSTANCE_ID=I.JOB_INSTANCE_ID" + (whereClause == null ? "" : " and " + whereClause);
 		if (whereClause != null) {

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDao.java
@@ -176,7 +176,7 @@ public class JdbcSearchableStepExecutionDao extends JdbcStepExecutionDao impleme
 		factory.setFromClause(getQuery("%PREFIX%STEP_EXECUTION S, %PREFIX%JOB_EXECUTION J, %PREFIX%JOB_INSTANCE I"));
 		factory.setSelectClause(FIELDS);
 		Map<String, Order> sortKeys = new HashMap<String, Order>();
-		sortKeys.put("S.STEP_EXECUTION_ID", Order.DESCENDING);
+		sortKeys.put("STEP_EXECUTION_ID", Order.DESCENDING);
 		factory.setSortKeys(sortKeys);
 		if (whereClause != null) {
 			factory.setWhereClause(whereClause


### PR DESCRIPTION
In my environment (Oracle) the DAO call "getJobExecutions("job", 1, 1)" actually does not work. I got an SqlException, saying:

bad SQL grammar [SELECT E.JOB_EXECUTION_ID FROM (SELECT E.JOB_EXECUTION_ID, ROWNUM as TMP_ROW_NUM FROM (SELECT E.JOB_EXECUTION_ID FROM BATCH_JOB_EXECUTION E, BATCH_JOB_INSTANCE I WHERE E.JOB_INSTANCE_ID=I.JOB_INSTANCE_ID and I.JOB_NAME=? ORDER BY E.JOB_EXECUTION_ID DESC)) WHERE TMP_ROW_NUM = 1]; nested exception is java.sql.SQLSyntaxErrorException: ORA-00904: "E"."JOB_EXECUTION_ID": invalid identifier

I identified the problem with selecting E.JOB_EXECUTION_ID in both outer selects without naming the inner select "E".

If I remove this prefix "E." the DAO call works as expected. 
