### PR TITLE
Display last job execution parameters

### DIFF
--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobController.java
@@ -166,7 +166,7 @@ public class JobController {
 
 			Collection<JobInstance> result = jobService.listJobInstances(jobName, startJobInstance, pageSize);
 			Collection<JobInstanceInfo> jobInstances = new ArrayList<JobInstanceInfo>();
-			model.addAttribute("jobParameters", "");
+			model.addAttribute("jobParameters", jobParametersExtractor.fromJobParameters(jobService.getLastJobParameters(jobName)));
 			for (JobInstance jobInstance : result) {
 				jobInstances.add(new JobInstanceInfo(jobInstance, jobService.getJobExecutionsForJobInstance(jobName,
 						jobInstance.getId())));

--- a/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/job.ftl
+++ b/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/job.ftl
@@ -30,6 +30,7 @@
 						<th>&nbsp;</th>
 						<th>JobExecution Count</th>
 						<th>Last JobExecution</th>
+						<th>Last JobExecution Parameters</th>
 					</tr>
 				</thead>
 				<tbody>
@@ -47,8 +48,10 @@
 							<#if jobInstanceInfo.lastJobExecution??>
 								<#assign execution_url><@spring.url relativeUrl="${servletPath}/jobs/executions/${jobInstanceInfo.lastJobExecution.id?c}"/></#assign>
 								<td><a href="${execution_url}">${jobInstanceInfo.lastJobExecution.status}</a></td>
+								<td>${jobInstanceInfo.lastJobExecution.jobParameters}</td>
 							<#else>
-								<td>?</td>							
+								<td>?</td>
+								<td>?</td>
 							</#if>
 						</tr>
 					</#list>

--- a/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/launch.ftl
+++ b/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/html/launch.ftl
@@ -11,7 +11,7 @@
 		<label for="launch">Job name=${jobInfo.name}</label><input id="launch" type="submit" value="Launch" name="launch" />
 		<ol>
 			<li><label for="jobParameters">Job Parameters (key=value
-			pairs)</label><textarea id="jobParameters" name="jobParameters" class="jobParameters"></textarea> 
+			pairs)</label><textarea id="jobParameters" name="jobParameters" class="jobParameters">${jobParameters}</textarea> 
 			(<#if jobInfo.incrementable>Incrementable<#else>Not incrementable</#if>)</li>
 		</ol>
 

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobControllerTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobControllerTests.java
@@ -35,9 +35,9 @@ import org.springframework.validation.BindException;
 
 public class JobControllerTests {
 
-	private JobService jobService = EasyMock.createMock(JobService.class);
+	private final JobService jobService = EasyMock.createMock(JobService.class);
 
-	private JobController controller = new JobController(jobService);
+	private final JobController controller = new JobController(jobService);
 
 	@Test
 	public void testJobNameSunnyDay() throws Exception {
@@ -89,6 +89,8 @@ public class JobControllerTests {
 		EasyMock.expectLastCall().andReturn(true);
 		jobService.isIncrementable("foo");
 		EasyMock.expectLastCall().andReturn(true);
+		jobService.getLastJobParameters("foo");
+		EasyMock.expectLastCall().andReturn(new JobParameters());
 		EasyMock.replay(jobService);
 
 		ExtendedModelMap model = new ExtendedModelMap();
@@ -145,6 +147,8 @@ public class JobControllerTests {
 		EasyMock.expectLastCall().andReturn(true);
 		jobService.isIncrementable("job");
 		EasyMock.expectLastCall().andReturn(true);
+		jobService.getLastJobParameters("job");
+		EasyMock.expectLastCall().andReturn(new JobParameters());
 		EasyMock.replay(jobService);
 
 		ExtendedModelMap model = new ExtendedModelMap();


### PR DESCRIPTION
@SEE: https://github.com/spring-projects/spring-batch-admin/pull/20

With switching to Spring-Batch 2.2.x the data model changed, so that JobParameters are no longer part of a JobInstance but of JobExecution.

I think because of this change the JobParameters column in job.ftl was deleted because it shows the JobInstances.

Like diplaying the status of the last JobExecution I included the it JobParameters as it was in spring-batch-admin 1.2.x.
