### PR TITLE
Fix javadoc building with JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,6 +415,7 @@
 				<configuration>
 					<aggregate>true</aggregate>
 					<breakiterator>true</breakiterator>
+					<additionalparam>-Xdoclint:none</additionalparam>
 					<links>
 						<link>http://java.sun.com/j2ee/1.4/docs/api</link>
 						<link>http://java.sun.com/j2se/1.5.0/docs/api</link>


### PR DESCRIPTION
Turn off javadoc checks for Java 8 as specified in this thread:
http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html