### PR TITLE
BATCHADM-221 Add job name to the executions.ftl JSON template

### DIFF
--- a/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/json/executions.ftl
+++ b/spring-batch-admin-manager/src/main/resources/org/springframework/batch/admin/web/manager/jobs/json/executions.ftl
@@ -5,6 +5,7 @@
 	<#if jobExecutions?? && jobExecutions?size!=0>
 	"jobExecutions" : {<#list jobExecutions as jobExecutionInfo><#assign url><@spring.url relativeUrl="${servletPath}/jobs/executions/${jobExecutionInfo.id?c}.json"/></#assign>
 		"${jobExecutionInfo.id}" : {
+			"name" : "${jobExecutionInfo.name}",
 			"status" : "${jobExecutionInfo.jobExecution.status}",
 			"startTime" : "${jobExecutionInfo.startTime}",
 			"duration" : "${jobExecutionInfo.duration}",


### PR DESCRIPTION
Add job name to executions.ftl for retrieval as JSON via GET operations.
Reason: TML view provides the job name but not the JSON view.
