### PR TITLE
Isolate ability to traverse directories when uploading files

### DIFF
--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
@@ -81,8 +81,6 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 		}
 		Assert.state(outputDir.exists(), "Output directory does not exist " + outputDir);
 		Assert.state(outputDir.isDirectory(), "Output file is not a directory " + outputDir);
-
-		System.out.println(">> OUTPUT DIR = " + outputDir.getAbsolutePath());
 	}
 
 	public FileInfo createFile(String path) throws IOException {
@@ -100,11 +98,9 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 		File directory = new File(outputDir, parent);
 
 		try {
-			System.out.println(">> Requested Path: " + new URI(directory.getAbsolutePath()).normalize().getPath());
-			System.out.println(">> Output Path: " + new URI(this.outputDir.getAbsolutePath()).normalize().getPath());
-		if(!new URI(directory.getAbsolutePath()).normalize().getPath().startsWith(this.outputDir.getAbsolutePath())) {
-			throw new IllegalArgumentException("Can not write to directory: " + directory.getAbsolutePath());
-		}
+			if(!new URI(directory.getAbsolutePath()).normalize().getPath().startsWith(this.outputDir.getAbsolutePath())) {
+				throw new IllegalArgumentException("Can not write to directory: " + directory.getAbsolutePath());
+			}
 		}
 		catch (URISyntaxException e) {
 			throw new IOException(e);
@@ -115,7 +111,6 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 
 		FileInfo result = new FileInfo(path);
 		File dest = new File(outputDir, result.getFileName());
-		System.out.println(">> file name = " + result.getFileName());
 		dest.createNewFile();
 
 		return result;

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
@@ -15,9 +15,19 @@
  */
 package org.springframework.batch.admin.service;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ContextResource;
@@ -28,13 +38,6 @@ import org.springframework.core.io.ResourceLoader;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternUtils;
 import org.springframework.util.Assert;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 /**
  * An implementation of {@link FileService} that deals with files only in the
@@ -78,6 +81,8 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 		}
 		Assert.state(outputDir.exists(), "Output directory does not exist " + outputDir);
 		Assert.state(outputDir.isDirectory(), "Output file is not a directory " + outputDir);
+
+		System.out.println(">> OUTPUT DIR = " + outputDir.getAbsolutePath());
 	}
 
 	public FileInfo createFile(String path) throws IOException {
@@ -93,11 +98,24 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 		}
 
 		File directory = new File(outputDir, parent);
+
+		try {
+			System.out.println(">> Requested Path: " + new URI(directory.getAbsolutePath()).normalize().getPath());
+			System.out.println(">> Output Path: " + new URI(this.outputDir.getAbsolutePath()).normalize().getPath());
+		if(!new URI(directory.getAbsolutePath()).normalize().getPath().startsWith(this.outputDir.getAbsolutePath())) {
+			throw new IllegalArgumentException("Can not write to directory: " + directory.getAbsolutePath());
+		}
+		}
+		catch (URISyntaxException e) {
+			throw new IOException(e);
+		}
+
 		directory.mkdirs();
 		Assert.state(directory.exists() && directory.isDirectory(), "Could not create directory: " + directory);
 
 		FileInfo result = new FileInfo(path);
 		File dest = new File(outputDir, result.getFileName());
+		System.out.println(">> file name = " + result.getFileName());
 		dest.createNewFile();
 
 		return result;
@@ -244,6 +262,7 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 				path = path.substring(1);
 			}
 		}
+
 		return path;
 	}
 

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/configuration-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/configuration-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p" xmlns:aop="http://www.springframework.org/schema/aop"
-	xmlns:file="http://www.springframework.org/schema/integration/file"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-		http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xmlns:file="http://www.springframework.org/schema/integration/file"
+			 xsi:schemaLocation="http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/file-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/file-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p" xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<publish-subscribe-channel id="input-files" />
@@ -15,6 +15,7 @@
 	<bean id="fileService" class="org.springframework.batch.admin.service.LocalFileService"
 			xmlns="http://www.springframework.org/schema/beans">
 		<property name="fileSender" ref="fileSender" />
+		<property name="outputDir" value="${batch.files.upload-dir:#{systemProperties['java.io.tmpdir']}}"/>
 	</bean>
 
 	<bean id="customEditorConfigurer" class="org.springframework.beans.factory.config.CustomEditorConfigurer"

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/launcher-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/launcher-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p" xmlns:aop="http://www.springframework.org/schema/aop"
-	xsi:schemaLocation="http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="job-requests" />

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/restart-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/restart-context.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+<beans:beans xmlns="http://www.springframework.org/schema/integration"
+			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+			 xmlns:beans="http://www.springframework.org/schema/beans"
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="job-launches" />

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests.java
@@ -1,8 +1,5 @@
 package org.springframework.batch.admin.service;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 
 import org.apache.commons.io.FileUtils;
@@ -11,6 +8,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.io.Resource;
@@ -22,6 +20,9 @@ import org.springframework.integration.core.MessageHandler;
 import org.springframework.integration.core.SubscribableChannel;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -48,6 +49,7 @@ public class LocalFileServiceIntegrationTests {
 
 	@Before
 	public void setUp() throws Exception {
+		System.out.println(">> temp dir = " + System.getProperty("java.io.tmpdir"));
 		FileUtils.deleteDirectory(service.getUploadDirectory());
 		files.unsubscribe(handler);
 		files.subscribe(handler);

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests.java
@@ -2,7 +2,6 @@ package org.springframework.batch.admin.service;
 
 import java.io.File;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
@@ -49,8 +48,14 @@ public class LocalFileServiceIntegrationTests {
 
 	@Before
 	public void setUp() throws Exception {
-		System.out.println(">> temp dir = " + System.getProperty("java.io.tmpdir"));
-		FileUtils.deleteDirectory(service.getUploadDirectory());
+		File bucket = new File(service.getUploadDirectory(), "spam/bucket");
+		if(bucket.exists()) {
+			bucket.delete();
+		}
+		File crap = new File(service.getUploadDirectory(), "spam/bucket/crap");
+		if(crap.exists()) {
+			crap.delete();
+		}
 		files.unsubscribe(handler);
 		files.subscribe(handler);
 	}

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceJobIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/LocalFileServiceJobIntegrationTests.java
@@ -1,14 +1,13 @@
 package org.springframework.batch.admin.service;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import java.io.File;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobExecution;
@@ -27,6 +26,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @ContextConfiguration
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -53,7 +55,14 @@ public class LocalFileServiceJobIntegrationTests {
 
 	@Before
 	public void setUp() throws Exception {
-		FileUtils.deleteDirectory(service.getUploadDirectory());
+		File bucket = new File(service.getUploadDirectory(), "foo/crap");
+		if(bucket.exists()) {
+			bucket.delete();
+		}
+		File crap = new File(service.getUploadDirectory(), "staging/crap");
+		if(crap.exists()) {
+			crap.delete();
+		}
 	}
 
 	@Test

--- a/spring-batch-admin-manager/src/test/resources/batch-derby.properties
+++ b/spring-batch-admin-manager/src/test/resources/batch-derby.properties
@@ -9,3 +9,4 @@ batch.schema.script=classpath:/org/springframework/batch/core/schema-derby.sql
 batch.drop.script=classpath:/org/springframework/batch/core/schema-drop-derby.sql
 batch.business.schema.script=business-schema-derby.sql
 batch.verify.cursor.position=false
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-manager/src/test/resources/batch-h2.properties
+++ b/spring-batch-admin-manager/src/test/resources/batch-h2.properties
@@ -8,3 +8,4 @@ batch.database.incrementer.class=org.springframework.jdbc.support.incrementer.H2
 batch.schema.script=classpath:/org/springframework/batch/core/schema-h2.sql
 batch.drop.script=classpath:/org/springframework/batch/core/schema-drop-h2.sql
 batch.business.schema.script=classpath:/business-schema-h2.sql
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-manager/src/test/resources/batch-hsql.properties
+++ b/spring-batch-admin-manager/src/test/resources/batch-hsql.properties
@@ -10,3 +10,4 @@ batch.database.incrementer.class=org.springframework.jdbc.support.incrementer.Hs
 batch.schema.script=classpath*:/org/springframework/batch/core/schema-hsqldb.sql
 batch.drop.script=classpath*:/org/springframework/batch/core/schema-drop-hsqldb.sql
 batch.business.schema.script=classpath*:/business-schema-hsqldb.sql
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-manager/src/test/resources/batch-mysql.properties
+++ b/spring-batch-admin-manager/src/test/resources/batch-mysql.properties
@@ -8,3 +8,4 @@ batch.database.incrementer.class=org.springframework.jdbc.support.incrementer.My
 batch.schema.script=classpath:/org/springframework/batch/core/schema-mysql.sql
 batch.drop.script=classpath:/org/springframework/batch/core/schema-drop-mysql.sql
 batch.business.schema.script=classpath:business-schema-mysql.sql
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests-context.xml
@@ -1,10 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://www.springframework.org/schema/beans" 
-	xmlns:integration="http://www.springframework.org/schema/integration"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="placeholderProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>classpath:/org/springframework/batch/admin/bootstrap/batch.properties</value>
+				<value>classpath:batch-default.properties</value>
+				<value>classpath:batch-${ENVIRONMENT:hsql}.properties</value>
+			</list>
+		</property>
+		<property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+		<property name="ignoreResourceNotFound" value="true" />
+		<property name="ignoreUnresolvablePlaceholders" value="false" />
+		<property name="order" value="1" />
+	</bean>
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/integration/file-context.xml" />
 

--- a/spring-batch-admin-parent/pom.xml
+++ b/spring-batch-admin-parent/pom.xml
@@ -24,17 +24,17 @@
 		<developer>
 			<id>dsyer</id>
 			<name>Dave Syer</name>
-			<email>dsyer@vmware.com</email>
+			<email>dsyer@pivotal.io</email>
 		</developer>
 		<developer>
 			<id>mminella</id>
 			<name>Michael Minella</name>
-			<email>mminella@vmware.com</email>
+			<email>mminella@pivotal.io</email>
 		</developer>
 		<developer>
 			<id>cschaefer</id>
 			<name>Chris Schaefer</name>
-			<email>cschaefer@gopivotal.com</email>
+			<email>cschaefer@pivotal.io</email>
 		</developer>
 	</developers>
 	<properties>

--- a/spring-batch-admin-sample/src/main/resources/batch-default.properties
+++ b/spring-batch-admin-sample/src/main/resources/batch-default.properties
@@ -3,3 +3,4 @@ batch.remote.base.url=http://localhost:8080/spring-batch-admin-sample
 
 # Non-platform dependent settings that you might like to change
 # batch.job.configuration.file.dir=target/config
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-sample/src/main/resources/batch-hsql.properties
+++ b/spring-batch-admin-sample/src/main/resources/batch-hsql.properties
@@ -14,3 +14,4 @@ batch.business.schema.script=classpath:/business-schema-hsqldb.sql
 
 # Non-platform dependent settings that you might like to change
 # batch.data.source.init=true
+# batch.files.upload-dir=/sba/input

--- a/spring-batch-admin-sample/src/main/resources/batch-mysql.properties
+++ b/spring-batch-admin-sample/src/main/resources/batch-mysql.properties
@@ -13,3 +13,4 @@ batch.database.incrementer.class=org.springframework.jdbc.support.incrementer.My
 
 # Non-platform dependent settings that you might like to change
 # batch.data.source.init=true
+# batch.files.upload-dir=/sba/input

--- a/src/site/apt/getting-started.apt
+++ b/src/site/apt/getting-started.apt
@@ -81,6 +81,12 @@ Getting Started with Spring Batch Admin
     wiped and re-created just set <<<batch.data.source.init=false>>>
     (in the properties file or as a System property).
 
+    * To configure where input files are uploaded to, add the property <<batch.files.upload-dir=/sba/input>>
+    to one of your batch configuration files.  By default, the java temp directory is used
+    <<System.getProperty("java.io.tmpdir")>>.  It's important to note that files are not
+    permitted to be uploaded into any directory other than the one configured or a
+    subdirectory of it.
+
 * Overriding Components from Spring Batch Admin
 
   The system tries to provide some useful defaults for things like transaction manager,


### PR DESCRIPTION
Requires that the path an input file is being uploaded to the, or a subdirectory of, the configured upload directory as defined by the `batch.files.upload-dir` property.