### PR TITLE
Build fails on windows.

### DIFF
--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
@@ -17,8 +17,6 @@ package org.springframework.batch.admin.service;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,7 +25,6 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.io.ContextResource;
@@ -97,14 +94,11 @@ public class LocalFileService implements FileService, InitializingBean, Resource
 
 		File directory = new File(outputDir, parent);
 
-		try {
-			if(!new URI(directory.getAbsolutePath()).normalize().getPath().startsWith(this.outputDir.getAbsolutePath())) {
-				throw new IllegalArgumentException("Can not write to directory: " + directory.getAbsolutePath());
-			}
-		}
-		catch (URISyntaxException e) {
-			throw new IOException(e);
-		}
+        String directoryCanonicalPath = directory.getCanonicalPath();
+        String outputDirCanonicalPath = this.outputDir.getCanonicalPath();
+        if (!directoryCanonicalPath.startsWith(outputDirCanonicalPath)) {
+			throw new IllegalArgumentException("Can not write to directory: " + directory.getAbsolutePath());
+        }
 
 		directory.mkdirs();
 		Assert.state(directory.exists() && directory.isDirectory(), "Could not create directory: " + directory);

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractIntegrationViewTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractIntegrationViewTests-context.xml
@@ -7,6 +7,20 @@
 						 http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
 						 http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
 
+	<bean id="placeholderProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+		<property name="locations">
+			<list>
+				<value>classpath:/org/springframework/batch/admin/bootstrap/batch.properties</value>
+				<value>classpath:batch-default.properties</value>
+				<value>classpath:batch-${ENVIRONMENT:hsql}.properties</value>
+			</list>
+		</property>
+		<property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_OVERRIDE" />
+		<property name="ignoreResourceNotFound" value="true" />
+		<property name="ignoreUnresolvablePlaceholders" value="false" />
+		<property name="order" value="1" />
+	</bean>
+
 	<import resource="classpath*:/META-INF/spring/batch/servlet/resources/*-context.xml"/>
 	<import resource="classpath*:/META-INF/spring/batch/servlet/manager/manager-context.xml"/>
 	<import resource="classpath*:/META-INF/spring/batch/servlet/manager/integration-context.xml"/>


### PR DESCRIPTION
The method URI#normalize fails on windows because of the colon ':' char
contained in the path (C:\path\to\file). I propose to use
File#getCanonicalPath instead. Plus a test fails (ConfigurationViewTests) because of the
${batch.files.upload-dir:#{systemProperties['java.io.tmpdir']}} parameter
in file-context.xml. Again the ':' char could have been an issue, but
anyway batch.files.upload-dir definition was missing for this test.