### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-batch-admin.git</developerConnection>
 	  <tag>HEAD</tag>
@@ -24,7 +24,7 @@
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 	<properties>
@@ -174,7 +174,7 @@
 				</plugin>
 				<plugin><!--
 						   run `mvn package assembly:assembly` to trigger assembly creation.
-						   see http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
+						   see https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
 				  <artifactId>maven-assembly-plugin</artifactId>
 				  <inherited>false</inherited>
 				  <executions>
@@ -418,19 +418,19 @@
 					<links>
 						<link>http://java.sun.com/j2ee/1.4/docs/api</link>
 						<link>http://java.sun.com/j2se/1.5.0/docs/api</link>
-						<link>http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
-						<link>http://jakarta.apache.org/commons/dbcp/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/fileupload/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/httpclient/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/pool/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/logging/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
+						<link>https://jakarta.apache.org/commons/dbcp/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/fileupload/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/httpclient/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/pool/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/logging/apidocs/</link>
 						<link>http://junit.sourceforge.net/javadoc/</link>
-						<link>http://logging.apache.org/log4j/docs/api/</link>
-						<link>http://jakarta.apache.org/regexp/apidocs/</link>
-						<link>http://jakarta.apache.org/velocity/api/</link>
-						<link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
-						<link>http://static.springframework.org/spring-batch/apidocs/</link>
-						<link>http://static.springframework.org/spring-ws/site/apidocs/</link>
+						<link>https://logging.apache.org/log4j/docs/api/</link>
+						<link>https://jakarta.apache.org/regexp/apidocs/</link>
+						<link>https://jakarta.apache.org/velocity/api/</link>
+						<link>https://docs.spring.io/spring/docs/3.0.x/javadoc-api/</link>
+						<link>https://docs.spring.io/spring-batch/apidocs/</link>
+						<link>https://docs.spring.io/spring-ws/site/apidocs/</link>
 					</links>
 				</configuration>
 			</plugin>

--- a/spring-batch-admin-parent/pom.xml
+++ b/spring-batch-admin-parent/pom.xml
@@ -6,10 +6,10 @@
 	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<name>Spring Batch Admin Parent</name>
 	<description>A set of services (Java, JSON) and a UI (webapp) for managing and launching Spring Batch jobs.</description>
-	<url>http://docs.spring.io/spring-batch-admin</url>
+	<url>https://docs.spring.io/spring-batch-admin</url>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</developerConnection>
 	  <tag>HEAD</tag>
@@ -17,7 +17,7 @@
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 	<developers>

--- a/spring-batch-admin-sample/pom.xml
+++ b/spring-batch-admin-sample/pom.xml
@@ -127,7 +127,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://s3.amazonaws.com/maven.springframework.org/milestone</url>
+			<url>https://s3.amazonaws.com/maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://junit.sourceforge.net/javadoc/ (200) migrated to:  
  http://junit.sourceforge.net/javadoc/ ([https](https://junit.sourceforge.net/javadoc/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jakarta.apache.org/regexp/apidocs/ (404) migrated to:  
  https://jakarta.apache.org/regexp/apidocs/ ([https](https://jakarta.apache.org/regexp/apidocs/) result 404).
* http://logging.apache.org/log4j/docs/api/ (404) migrated to:  
  https://logging.apache.org/log4j/docs/api/ ([https](https://logging.apache.org/log4j/docs/api/) result 404).
* http://s3.amazonaws.com/maven.springframework.org/milestone (404) migrated to:  
  https://s3.amazonaws.com/maven.springframework.org/milestone ([https](https://s3.amazonaws.com/maven.springframework.org/milestone) result 404).
* http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html (301) migrated to:  
  https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html ([https](https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://static.springframework.org/spring-ws/site/apidocs/ (301) migrated to:  
  https://docs.spring.io/spring-ws/site/apidocs/ ([https](https://static.springframework.org/spring-ws/site/apidocs/) result 200).
* http://static.springsource.org/spring/docs/3.0.x/javadoc-api/ (301) migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api/ ([https](https://static.springsource.org/spring/docs/3.0.x/javadoc-api/) result 200).
* http://github.com/spring-projects/spring-batch-admin migrated to:  
  https://github.com/spring-projects/spring-batch-admin ([https](https://github.com/spring-projects/spring-batch-admin) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring-batch/apidocs/ (301) migrated to:  
  https://docs.spring.io/spring-batch/apidocs/ ([https](https://static.springframework.org/spring-batch/apidocs/) result 301).
* http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ migrated to:  
  https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ ([https](https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/) result 301).
* http://jakarta.apache.org/commons/dbcp/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/dbcp/apidocs/ ([https](https://jakarta.apache.org/commons/dbcp/apidocs/) result 301).
* http://jakarta.apache.org/commons/fileupload/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/fileupload/apidocs/ ([https](https://jakarta.apache.org/commons/fileupload/apidocs/) result 301).
* http://jakarta.apache.org/commons/httpclient/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/httpclient/apidocs/ ([https](https://jakarta.apache.org/commons/httpclient/apidocs/) result 301).
* http://jakarta.apache.org/commons/logging/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/logging/apidocs/ ([https](https://jakarta.apache.org/commons/logging/apidocs/) result 301).
* http://jakarta.apache.org/commons/pool/apidocs/ migrated to:  
  https://jakarta.apache.org/commons/pool/apidocs/ ([https](https://jakarta.apache.org/commons/pool/apidocs/) result 301).
* http://jakarta.apache.org/velocity/api/ migrated to:  
  https://jakarta.apache.org/velocity/api/ ([https](https://jakarta.apache.org/velocity/api/) result 301).
* http://docs.spring.io/spring-batch-admin migrated to:  
  https://docs.spring.io/spring-batch-admin ([https](https://docs.spring.io/spring-batch-admin) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/j2ee/1.4/docs/api
* http://java.sun.com/j2se/1.5.0/docs/api
* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance