### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.batch</groupId>
 	<artifactId>spring-batch-admin</artifactId>
@@ -8,20 +8,20 @@
 	<version>1.3.2.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-batch-admin.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 	<issueManagement>
 		<system>JIRA</system>
-		<url>http://opensource.atlassian.com/projects/spring/browse/BATCHADM</url>
+		<url>https://opensource.atlassian.com/projects/spring/browse/BATCHADM</url>
 	</issueManagement>
 	<mailingLists>
 		<mailingList>
 			<name>Spring Batch Forum</name>
-			<post>http://forum.springframework.org/forumdisplay.php?f=41</post>
-			<archive>http://forum.springframework.org/forumdisplay.php?f=41</archive>
+			<post>https://forum.springframework.org/forumdisplay.php?f=41</post>
+			<archive>https://forum.springframework.org/forumdisplay.php?f=41</archive>
 		</mailingList>
 	</mailingLists>
 	<ciManagement>
@@ -31,7 +31,7 @@
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 	<properties>
@@ -181,7 +181,7 @@
 				</plugin>
 				<plugin><!--
 						   run `mvn package assembly:assembly` to trigger assembly creation.
-						   see http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
+						   see https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
 				  <artifactId>maven-assembly-plugin</artifactId>
 				  <inherited>false</inherited>
 				  <executions>
@@ -423,21 +423,21 @@
 					<aggregate>true</aggregate>
 					<breakiterator>true</breakiterator>
 					<links>
-						<link>http://java.sun.com/j2ee/1.4/docs/api</link>
-						<link>http://java.sun.com/j2se/1.5.0/docs/api</link>
-						<link>http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
-						<link>http://jakarta.apache.org/commons/dbcp/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/fileupload/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/httpclient/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/pool/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/logging/apidocs/</link>
+						<link>https://java.sun.com/j2ee/1.4/docs/api</link>
+						<link>https://java.sun.com/j2se/1.5.0/docs/api</link>
+						<link>https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
+						<link>https://jakarta.apache.org/commons/dbcp/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/fileupload/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/httpclient/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/pool/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/logging/apidocs/</link>
 						<link>http://junit.sourceforge.net/javadoc/</link>
-						<link>http://logging.apache.org/log4j/docs/api/</link>
-						<link>http://jakarta.apache.org/regexp/apidocs/</link>
-						<link>http://jakarta.apache.org/velocity/api/</link>
-						<link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
-						<link>http://static.springframework.org/spring-batch/apidocs/</link>
-						<link>http://static.springframework.org/spring-ws/site/apidocs/</link>
+						<link>https://logging.apache.org/log4j/docs/api/</link>
+						<link>https://jakarta.apache.org/regexp/apidocs/</link>
+						<link>https://jakarta.apache.org/velocity/api/</link>
+						<link>https://docs.spring.io/spring/docs/3.0.x/javadoc-api/</link>
+						<link>https://docs.spring.io/spring-batch/apidocs/</link>
+						<link>https://docs.spring.io/spring-ws/site/apidocs/</link>
 					</links>
 				</configuration>
 			</plugin>

--- a/spring-batch-admin-manager/pom.xml
+++ b/spring-batch-admin-manager/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-admin-manager</artifactId>
 	<packaging>jar</packaging>

--- a/spring-batch-admin-parent/pom.xml
+++ b/spring-batch-admin-parent/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.batch</groupId>
 	<artifactId>spring-batch-admin-parent</artifactId>
 	<version>1.3.2.BUILD-SNAPSHOT</version>
 	<name>Spring Batch Admin Parent</name>
 	<description>A set of services (Java, JSON) and a UI (webapp) for managing and launching Spring Batch jobs.</description>
-	<url>http://docs.spring.io/spring-batch-admin</url>
+	<url>https://docs.spring.io/spring-batch-admin</url>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</developerConnection>
     <tag>HEAD</tag>
@@ -17,7 +17,7 @@
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 	<developers>
@@ -697,7 +697,7 @@
 			<!-- This has to be defined and visible in default profile for bundlor to work -->
 			<id>spring-ebr</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -723,7 +723,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://maven.springframework.org/milestone/</url>
+			<url>https://maven.springframework.org/milestone/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -731,12 +731,12 @@
 		<repository>
 			<id>spring-snapshots</id>
 			<name>Spring Maven Snapshot Repository</name>
-			<url>http://maven.springframework.org/snapshot/</url>
+			<url>https://maven.springframework.org/snapshot/</url>
 		</repository>
 		<repository>
 			<id>spring-ebr</id>
 			<name>Spring Enterprise Bundle Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release/</url>
+			<url>https://repository.springsource.com/maven/bundles/release/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -744,7 +744,7 @@
 		<repository>
 			<id>objectstyle</id>
 			<name>ObjectStyle.org Repository</name>
-			<url>http://objectstyle.org/maven2</url>
+			<url>http://objectstyle.org/maven2/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/spring-batch-admin-resources/pom.xml
+++ b/spring-batch-admin-resources/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<description>Extensible UI framework and basic styles and layout for Spring Batch Admin console.</description>
 	<parent>
@@ -117,7 +117,7 @@
 			<!-- This has to be defined and visible in default profile for bundlor to work -->
 			<id>spring-ebr</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>
@@ -128,7 +128,7 @@
 			<!-- This has to be defined and visible in default profile for bundlor to work -->
 			<id>spring-ebr</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/spring-batch-admin-sample/pom.xml
+++ b/spring-batch-admin-sample/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-admin-sample</artifactId>
 	<description>A sample web application (WAR project) for Spring Batch Admin console.</description>
@@ -126,7 +126,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://s3.amazonaws.com/maven.springframework.org/milestone</url>
+			<url>https://s3.amazonaws.com/maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/spring-batch-integration/pom.xml
+++ b/spring-batch-integration/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-integration</artifactId>
 	<name>Spring Batch Integration</name>
-	<url>http://static.springframework.org/spring-batch/${project.artifactId}</url>
+	<url>https://docs.spring.io/spring-batch/${project.artifactId}</url>
 	<parent>
 		<groupId>org.springframework.batch</groupId>
 		<artifactId>spring-batch-admin-parent</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://junit.sourceforge.net/javadoc/ (200) with 1 occurrences could not be migrated:  
   ([https](https://junit.sourceforge.net/javadoc/) result AnnotatedConnectException).
* http://objectstyle.org/maven2 (301) with 1 occurrences could not be migrated:  
   ([https](https://objectstyle.org/maven2) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jakarta.apache.org/regexp/apidocs/ (404) with 1 occurrences migrated to:  
  https://jakarta.apache.org/regexp/apidocs/ ([https](https://jakarta.apache.org/regexp/apidocs/) result 404).
* http://logging.apache.org/log4j/docs/api/ (404) with 1 occurrences migrated to:  
  https://logging.apache.org/log4j/docs/api/ ([https](https://logging.apache.org/log4j/docs/api/) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 3 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://repository.springsource.com/maven/bundles/release/ (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release/ ([https](https://repository.springsource.com/maven/bundles/release/) result 404).
* http://s3.amazonaws.com/maven.springframework.org/milestone (404) with 1 occurrences migrated to:  
  https://s3.amazonaws.com/maven.springframework.org/milestone ([https](https://s3.amazonaws.com/maven.springframework.org/milestone) result 404).
* http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html (301) with 1 occurrences migrated to:  
  https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html ([https](https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springframework.org/spring-ws/site/apidocs/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/site/apidocs/ ([https](https://static.springframework.org/spring-ws/site/apidocs/) result 200).
* http://static.springsource.org/spring/docs/3.0.x/javadoc-api/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api/ ([https](https://static.springsource.org/spring/docs/3.0.x/javadoc-api/) result 200).
* http://github.com/spring-projects/spring-batch-admin with 2 occurrences migrated to:  
  https://github.com/spring-projects/spring-batch-admin ([https](https://github.com/spring-projects/spring-batch-admin) result 200).
* http://maven.springframework.org/milestone/ with 1 occurrences migrated to:  
  https://maven.springframework.org/milestone/ ([https](https://maven.springframework.org/milestone/) result 200).
* http://maven.springframework.org/snapshot/ with 1 occurrences migrated to:  
  https://maven.springframework.org/snapshot/ ([https](https://maven.springframework.org/snapshot/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 2 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring-batch/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/ ([https](https://static.springframework.org/spring-batch/) result 301).
* http://static.springframework.org/spring-batch/apidocs/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/apidocs/ ([https](https://static.springframework.org/spring-batch/apidocs/) result 301).
* http://forum.springframework.org/forumdisplay.php?f=41 with 2 occurrences migrated to:  
  https://forum.springframework.org/forumdisplay.php?f=41 ([https](https://forum.springframework.org/forumdisplay.php?f=41) result 301).
* http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ ([https](https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/) result 301).
* http://jakarta.apache.org/commons/dbcp/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/dbcp/apidocs/ ([https](https://jakarta.apache.org/commons/dbcp/apidocs/) result 301).
* http://jakarta.apache.org/commons/fileupload/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/fileupload/apidocs/ ([https](https://jakarta.apache.org/commons/fileupload/apidocs/) result 301).
* http://jakarta.apache.org/commons/httpclient/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/httpclient/apidocs/ ([https](https://jakarta.apache.org/commons/httpclient/apidocs/) result 301).
* http://jakarta.apache.org/commons/logging/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/logging/apidocs/ ([https](https://jakarta.apache.org/commons/logging/apidocs/) result 301).
* http://jakarta.apache.org/commons/pool/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/pool/apidocs/ ([https](https://jakarta.apache.org/commons/pool/apidocs/) result 301).
* http://jakarta.apache.org/velocity/api/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/velocity/api/ ([https](https://jakarta.apache.org/velocity/api/) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://opensource.atlassian.com/projects/spring/browse/BATCHADM with 1 occurrences migrated to:  
  https://opensource.atlassian.com/projects/spring/browse/BATCHADM ([https](https://opensource.atlassian.com/projects/spring/browse/BATCHADM) result 301).
* http://docs.spring.io/spring-batch-admin with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch-admin ([https](https://docs.spring.io/spring-batch-admin) result 302).
* http://java.sun.com/j2ee/1.4/docs/api with 1 occurrences migrated to:  
  https://java.sun.com/j2ee/1.4/docs/api ([https](https://java.sun.com/j2ee/1.4/docs/api) result 302).
* http://java.sun.com/j2se/1.5.0/docs/api with 1 occurrences migrated to:  
  https://java.sun.com/j2se/1.5.0/docs/api ([https](https://java.sun.com/j2se/1.5.0/docs/api) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 12 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 6 occurrences