### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.batch</groupId>
 	<artifactId>spring-batch-admin</artifactId>
@@ -8,7 +8,7 @@
 	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-batch-admin.git</developerConnection>
 	  <tag>HEAD</tag>
@@ -174,7 +174,7 @@
 				</plugin>
 				<plugin><!--
 						   run `mvn package assembly:assembly` to trigger assembly creation.
-						   see http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
+						   see https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html -->
 				  <artifactId>maven-assembly-plugin</artifactId>
 				  <inherited>false</inherited>
 				  <executions>
@@ -416,21 +416,21 @@
 					<aggregate>true</aggregate>
 					<breakiterator>true</breakiterator>
 					<links>
-						<link>http://java.sun.com/j2ee/1.4/docs/api</link>
-						<link>http://java.sun.com/j2se/1.5.0/docs/api</link>
-						<link>http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
-						<link>http://jakarta.apache.org/commons/dbcp/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/fileupload/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/httpclient/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/pool/apidocs/</link>
-						<link>http://jakarta.apache.org/commons/logging/apidocs/</link>
+						<link>https://java.sun.com/j2ee/1.4/docs/api</link>
+						<link>https://java.sun.com/j2se/1.5.0/docs/api</link>
+						<link>https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/</link>
+						<link>https://jakarta.apache.org/commons/dbcp/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/fileupload/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/httpclient/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/pool/apidocs/</link>
+						<link>https://jakarta.apache.org/commons/logging/apidocs/</link>
 						<link>http://junit.sourceforge.net/javadoc/</link>
-						<link>http://logging.apache.org/log4j/docs/api/</link>
-						<link>http://jakarta.apache.org/regexp/apidocs/</link>
-						<link>http://jakarta.apache.org/velocity/api/</link>
-						<link>http://static.springsource.org/spring/docs/3.0.x/javadoc-api/</link>
-						<link>http://static.springframework.org/spring-batch/apidocs/</link>
-						<link>http://static.springframework.org/spring-ws/site/apidocs/</link>
+						<link>https://logging.apache.org/log4j/docs/api/</link>
+						<link>https://jakarta.apache.org/regexp/apidocs/</link>
+						<link>https://jakarta.apache.org/velocity/api/</link>
+						<link>https://docs.spring.io/spring/docs/3.0.x/javadoc-api/</link>
+						<link>https://docs.spring.io/spring-batch/apidocs/</link>
+						<link>https://docs.spring.io/spring-ws/site/apidocs/</link>
 					</links>
 				</configuration>
 			</plugin>

--- a/spring-batch-admin-domain/pom.xml
+++ b/spring-batch-admin-domain/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-admin-domain</artifactId>
 	<packaging>jar</packaging>

--- a/spring-batch-admin-manager/pom.xml
+++ b/spring-batch-admin-manager/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-admin-manager</artifactId>
 	<packaging>jar</packaging>

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/configuration-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/configuration-context.xml
@@ -2,9 +2,9 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:file="http://www.springframework.org/schema/integration/file"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="job-configuration-requests" />
 	<channel id="job-configuration-files" />

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/file-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/file-context.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<publish-subscribe-channel id="input-files" />
 	

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/jmx-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/jmx-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int-jmx="http://www.springframework.org/schema/integration/jmx"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/jmx http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/jmx https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<int-jmx:mbean-export id="integrationMBeanExporter" default-domain="spring.application" server="mbeanServer" />
 </beans>

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/launcher-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/launcher-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans xmlns="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:beans="http://www.springframework.org/schema/beans"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="job-requests" />
 	<!-- TODO: filter into success and failure channels -->

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/restart-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/integration/restart-context.xml
@@ -2,8 +2,8 @@
 <beans:beans xmlns="http://www.springframework.org/schema/integration"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xmlns:beans="http://www.springframework.org/schema/beans"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<channel id="job-launches" />
 	<channel id="job-restarts" />

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/data-source-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/data-source-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="dataSource"
 		class="org.apache.commons.dbcp.BasicDataSource">

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/env-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/env-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!--  Use this to set additional properties on beans at run time -->
 	<bean id="placeholderProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/execution-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/execution-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xmlns:task="http://www.springframework.org/schema/task"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/task http://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<!-- Workaround for INT-1831 -->
 	<bean id="dummy" class="java.util.Date" />

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/jmx-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/bootstrap/manager/jmx-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<context:mbean-server id="mbeanServer" />
 

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/controller-context-legacy.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/controller-context-legacy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:util="http://www.springframework.org/schema/util"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<!--<context:annotation-config />-->
 

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/controller-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/controller-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config/>
 	<bean class="org.springframework.batch.admin.web.RestConfiguration"/>

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/integration-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/integration-context.xml
@@ -2,9 +2,9 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:integration="http://www.springframework.org/schema/integration" xmlns:http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                                 http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-                                 http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
-                                 http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+                                 https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+                                 http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+                                 http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="multipartResolver" class="org.springframework.web.multipart.commons.CommonsMultipartResolver" />
 

--- a/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/manager-context.xml
+++ b/spring-batch-admin-manager/src/main/resources/META-INF/spring/batch/servlet/manager/manager-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                                 http://www.springframework.org/schema/beans/spring-beans.xsd">
+                                 https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.batch.admin.web.HomeMenu" parent="baseMenu"/>
 	<bean class="org.springframework.batch.admin.web.JobsMenu" parent="baseMenu"/>

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/dummy-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/dummy-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<!-- Workaround for INT-1831 -->
 	<bean id="dummy" class="java.util.Date"/>

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/jmx/BatchMBeanExporterIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/jmx/BatchMBeanExporterIntegrationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/jmx/BatchMBeanExporterNoStepsIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/jmx/BatchMBeanExporterNoStepsIntegrationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/launch/JobLauncherSynchronizerIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/launch/JobLauncherSynchronizerIntegrationTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xmlns:beans="http://www.springframework.org/schema/beans"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/FileDropJobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/FileDropJobIntegrationTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:file="http://www.springframework.org/schema/integration/file" xmlns:integration="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration/file http://www.springframework.org/schema/integration/file/spring-integration-file.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/file https://www.springframework.org/schema/integration/file/spring-integration-file.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd"
 	xmlns:beans="http://www.springframework.org/schema/beans">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/integration/launcher-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobConfigurationRequestIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobConfigurationRequestIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p">
 
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/configuration-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobLaunchIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/JobLaunchIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p">
 
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/launcher-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/RestartJobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/RestartJobIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p">
 
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/launcher-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/StringPayloadJobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/StringPayloadJobIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/launcher-context.xml" />
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/restart-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/WireTapJobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/sample/WireTapJobIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd"
 	xmlns:beans="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p">
 
 	<import resource="classpath:/META-INF/spring/batch/bootstrap/integration/launcher-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/JobLocatorStepLocatorIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/JobLocatorStepLocatorIntegrationTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:integration="http://www.springframework.org/schema/integration"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<bean id="stepLocator" class="org.springframework.batch.admin.service.JobLocatorStepLocator">
 		<property name="jobLocator" ref="jobRegistry"></property>

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceIntegrationTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="placeholderProperties" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
 		<property name="locations">

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceJobIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/LocalFileServiceJobIntegrationTests-context.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:beans="http://www.springframework.org/schema/beans"
 	xmlns:integration="http://www.springframework.org/schema/integration" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/job-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/service/job-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<job id="job" xmlns="http://www.springframework.org/schema/batch">
 		<step id="step">

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/BatchJobsControllerIntegrationTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/BatchJobsControllerIntegrationTests-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<!--<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/*-context.xml"/>-->
 

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractIntegrationViewTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractIntegrationViewTests-context.xml
@@ -3,9 +3,9 @@
 	xmlns:integration="http://www.springframework.org/schema/integration"
 	xmlns:http="http://www.springframework.org/schema/integration/http"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-						 http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-						 http://www.springframework.org/schema/integration/http http://www.springframework.org/schema/integration/http/spring-integration-http.xsd
-						 http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd">
+						 https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+						 http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+						 http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/servlet/resources/*-context.xml"/>
 	<import resource="classpath*:/META-INF/spring/batch/servlet/manager/manager-context.xml"/>

--- a/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractManagerViewTests-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/org/springframework/batch/admin/web/views/AbstractManagerViewTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/servlet/resources/*.xml"/>
 	<import resource="classpath*:/META-INF/spring/batch/servlet/manager/manager*.xml"/>

--- a/spring-batch-admin-manager/src/test/resources/staging-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/staging-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd">
 
 	<job id="staging" xmlns="http://www.springframework.org/schema/batch">
 		<step id="staging-step">

--- a/spring-batch-admin-manager/src/test/resources/test-config.xml
+++ b/spring-batch-admin-manager/src/test/resources/test-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/env-context.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/data-source-context.xml" />

--- a/spring-batch-admin-manager/src/test/resources/test-job-context.xml
+++ b/spring-batch-admin-manager/src/test/resources/test-job-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd"
 	xmlns:context="http://www.springframework.org/schema/context">
 
 	<job id="test-job" xmlns="http://www.springframework.org/schema/batch">

--- a/spring-batch-admin-parent/pom.xml
+++ b/spring-batch-admin-parent/pom.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.batch</groupId>
 	<artifactId>spring-batch-admin-parent</artifactId>
 	<version>2.0.0.BUILD-SNAPSHOT</version>
 	<name>Spring Batch Admin Parent</name>
 	<description>A set of services (Java, JSON) and a UI (webapp) for managing and launching Spring Batch jobs.</description>
-	<url>http://docs.spring.io/spring-batch-admin</url>
+	<url>https://docs.spring.io/spring-batch-admin</url>
 	<packaging>pom</packaging>
 	<scm>
-		<url>http://github.com/spring-projects/spring-batch-admin</url>
+		<url>https://github.com/spring-projects/spring-batch-admin</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</connection>
 		<developerConnection>scm:git:git://github.com/spring-projects/spring-batch-admin.git</developerConnection>
 	  <tag>HEAD</tag>

--- a/spring-batch-admin-parent/src/site/site.xml
+++ b/spring-batch-admin-parent/src/site/site.xml
@@ -2,7 +2,7 @@
 <project name="${project.name}">
   <bannerLeft>
     <name>${project.name}</name>
-    <href>http://projects.spring.io/spring-batch/</href>
+    <href>https://projects.spring.io/spring-batch/</href>
   </bannerLeft>
   <bannerRight>
     <src>images/shim.gif</src>
@@ -17,7 +17,7 @@
   </skin>
 	<body>
 		<links>
-			<item name="Home" href="http://static.springframework.org/spring-batch/index.html"/>
+			<item name="Home" href="https://docs.spring.io/spring-batch/index.html"/>
 		</links>
 	</body>
 </project>

--- a/spring-batch-admin-resources/pom.xml
+++ b/spring-batch-admin-resources/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<description>Extensible UI framework and basic styles and layout for Spring Batch Admin console.</description>
 	<parent>

--- a/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/bootstrap/resources/resources-context.xml
+++ b/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/bootstrap/resources/resources-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans
-                                 http://www.springframework.org/schema/beans/spring-beans.xsd">
+                                 https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="resourceService" class="org.springframework.batch.admin.web.resources.DefaultResourceService"/>
 

--- a/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/servlet/resources/resources-context.xml
+++ b/spring-batch-admin-resources/src/main/resources/META-INF/spring/batch/servlet/resources/resources-context.xml
@@ -2,10 +2,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context" xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
-	xsi:schemaLocation="http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:annotation-config />
 

--- a/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/WEB-INF/web.xml
+++ b/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 			http://java.sun.com/xml/ns/j2ee
-			http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
+			https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>

--- a/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/servlet-config.xml
+++ b/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/servlet-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
  	<import resource="classpath*:/META-INF/spring/batch/servlet/resources/*.xml" />
  	<import resource="classpath*:/META-INF/spring/batch/servlet/manager/*.xml" />

--- a/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/webapp-config.xml
+++ b/spring-batch-admin-resources/src/main/resources/org/springframework/batch/admin/web/resources/webapp-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<!-- Workaround for INT-1831 -->
 	<bean id="dummy" class="java.util.Date"/>

--- a/spring-batch-admin-resources/src/test/resources/org/springframework/batch/admin/web/views/AbstractResourceViewTests-context.xml
+++ b/spring-batch-admin-resources/src/test/resources/org/springframework/batch/admin/web/views/AbstractResourceViewTests-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:context="http://www.springframework.org/schema/context"
-	   xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/**/*.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/servlet/resources/*.xml" />

--- a/spring-batch-admin-sample/pom.xml
+++ b/spring-batch-admin-sample/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-batch-admin-sample</artifactId>
 	<description>A sample web application (WAR project) for Spring Batch Admin console.</description>
@@ -127,7 +127,7 @@
 		<repository>
 			<id>spring-milestones</id>
 			<name>Spring Maven Milestone Repository</name>
-			<url>http://s3.amazonaws.com/maven.springframework.org/milestone</url>
+			<url>https://s3.amazonaws.com/maven.springframework.org/milestone</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>

--- a/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/jobs/infinite-context.xml
+++ b/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/jobs/infinite-context.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<job id="infinite" xmlns="http://www.springframework.org/schema/batch">
 		<step id="step1" next="step1">

--- a/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/jobs/jobs-context.xml
+++ b/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/jobs/jobs-context.xml
@@ -2,10 +2,10 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:context="http://www.springframework.org/schema/context"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/batch http://www.springframework.org/schema/batch/spring-batch-2.2.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch-2.2.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<job id="job1" xmlns="http://www.springframework.org/schema/batch" incrementer="incrementer">
 		<step id="step1" parent="step" />

--- a/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/servlet/override/service-context.xml
+++ b/spring-batch-admin-sample/src/main/resources/META-INF/spring/batch/servlet/override/service-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
 	<bean parent="placeholderProperties" />
 

--- a/spring-batch-admin-sample/src/main/resources/launch-context.xml
+++ b/spring-batch-admin-sample/src/main/resources/launch-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
     <description><![CDATA[
 	  A convenient aggregating config file for running the jobs in this project

--- a/spring-batch-admin-sample/src/main/webapp/WEB-INF/web.xml
+++ b/spring-batch-admin-sample/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
 <web-app xmlns="http://java.sun.com/xml/ns/j2ee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 			http://java.sun.com/xml/ns/j2ee
-			http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
+			https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd" version="2.4">
 
 	<context-param>
 		<param-name>contextConfigLocation</param-name>

--- a/spring-batch-admin-sample/src/test/resources/org/springframework/batch/admin/sample/JobExecutionTests-context.xml
+++ b/spring-batch-admin-sample/src/test/resources/org/springframework/batch/admin/sample/JobExecutionTests-context.xml
@@ -1,7 +1,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:integration="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
  	<import resource="classpath*:/META-INF/spring/batch/bootstrap/resources/*.xml" />
  	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/*.xml" />

--- a/spring-batch-admin-sample/src/test/resources/org/springframework/batch/admin/sample/JobIntegrationTests-context.xml
+++ b/spring-batch-admin-sample/src/test/resources/org/springframework/batch/admin/sample/JobIntegrationTests-context.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:integration="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/integration http://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/resources/*.xml" />
 	<import resource="classpath*:/META-INF/spring/batch/bootstrap/manager/*.xml" />

--- a/src/books/reference.xml
+++ b/src/books/reference.xml
@@ -1,5 +1,5 @@
 <book xmlns="http://maven.apache.org/BOOK/1.0.0"
-	xsi:schemaLocation="http://maven.apache.org/BOOK/1.0.0 http://maven.apache.org/xsd/book-1.0.0.xsd"
+	xsi:schemaLocation="http://maven.apache.org/BOOK/1.0.0 https://maven.apache.org/xsd/book-1.0.0.xsd"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<id>reference</id>
 	<author>Dave Syer</author>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <project name="${project.name}" xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 https://maven.apache.org/xsd/decoration-1.0.0.xsd">
 
 	<bannerLeft>
 		<name>${project.name}</name>
-		<href>http://projects.spring.io/spring-batch/
+		<href>https://projects.spring.io/spring-batch/
 		</href>
 	</bannerLeft>
 
@@ -29,7 +29,7 @@
 
 		<links>
 			<item name="Home"
-				href="http://docs.spring.io/spring-batch-admin/" />
+				href="https://docs.spring.io/spring-batch-admin/" />
 		</links>
 
 		<menu name="Documentation" inherit="none">
@@ -41,7 +41,7 @@
 
 		<menu name="Support" inherit="none">
 			<item name="Building" href="building.html" />
-			<item name="JIRA" href="http://jira.spring.io/browse/BATCHADM" />
+			<item name="JIRA" href="https://jira.spring.io/browse/BATCHADM" />
 		</menu>
 
 		<menu name="Modules" inherit="none">


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://junit.sourceforge.net/javadoc/ (200) with 1 occurrences could not be migrated:  
   ([https](https://junit.sourceforge.net/javadoc/) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://jakarta.apache.org/regexp/apidocs/ (404) with 1 occurrences migrated to:  
  https://jakarta.apache.org/regexp/apidocs/ ([https](https://jakarta.apache.org/regexp/apidocs/) result 404).
* http://logging.apache.org/log4j/docs/api/ (404) with 1 occurrences migrated to:  
  https://logging.apache.org/log4j/docs/api/ ([https](https://logging.apache.org/log4j/docs/api/) result 404).
* http://s3.amazonaws.com/maven.springframework.org/milestone (404) with 1 occurrences migrated to:  
  https://s3.amazonaws.com/maven.springframework.org/milestone ([https](https://s3.amazonaws.com/maven.springframework.org/milestone) result 404).
* http://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html (301) with 1 occurrences migrated to:  
  https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html ([https](https://www.sonatype.com/books/mvnref-book/reference/assemblies-set-dist-assemblies.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://static.springframework.org/spring-ws/site/apidocs/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-ws/site/apidocs/ ([https](https://static.springframework.org/spring-ws/site/apidocs/) result 200).
* http://static.springsource.org/spring/docs/3.0.x/javadoc-api/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.0.x/javadoc-api/ ([https](https://static.springsource.org/spring/docs/3.0.x/javadoc-api/) result 200).
* http://github.com/spring-projects/spring-batch-admin with 2 occurrences migrated to:  
  https://github.com/spring-projects/spring-batch-admin ([https](https://github.com/spring-projects/spring-batch-admin) result 200).
* http://jira.spring.io/browse/BATCHADM with 1 occurrences migrated to:  
  https://jira.spring.io/browse/BATCHADM ([https](https://jira.spring.io/browse/BATCHADM) result 200).
* http://maven.apache.org/xsd/book-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/book-1.0.0.xsd ([https](https://maven.apache.org/xsd/book-1.0.0.xsd) result 200).
* http://maven.apache.org/xsd/decoration-1.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/decoration-1.0.0.xsd ([https](https://maven.apache.org/xsd/decoration-1.0.0.xsd) result 200).
* http://projects.spring.io/spring-batch/ with 2 occurrences migrated to:  
  https://projects.spring.io/spring-batch/ ([https](https://projects.spring.io/spring-batch/) result 200).
* http://www.springframework.org/schema/aop/spring-aop.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop.xsd ([https](https://www.springframework.org/schema/aop/spring-aop.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch-2.2.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch-2.2.xsd ([https](https://www.springframework.org/schema/batch/spring-batch-2.2.xsd) result 200).
* http://www.springframework.org/schema/batch/spring-batch.xsd with 4 occurrences migrated to:  
  https://www.springframework.org/schema/batch/spring-batch.xsd ([https](https://www.springframework.org/schema/batch/spring-batch.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.5.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.5.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.5.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 5 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans.xsd with 37 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context-3.0.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.0.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.0.xsd) result 200).
* http://www.springframework.org/schema/context/spring-context.xsd with 6 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* http://www.springframework.org/schema/integration/file/spring-integration-file.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/file/spring-integration-file.xsd ([https](https://www.springframework.org/schema/integration/file/spring-integration-file.xsd) result 200).
* http://www.springframework.org/schema/integration/http/spring-integration-http.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/integration/http/spring-integration-http.xsd ([https](https://www.springframework.org/schema/integration/http/spring-integration-http.xsd) result 200).
* http://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd ([https](https://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd) result 200).
* http://www.springframework.org/schema/integration/spring-integration.xsd with 12 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).
* http://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd ([https](https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd) result 200).
* http://www.springframework.org/schema/mvc/spring-mvc.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/mvc/spring-mvc.xsd ([https](https://www.springframework.org/schema/mvc/spring-mvc.xsd) result 200).
* http://www.springframework.org/schema/task/spring-task.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/task/spring-task.xsd ([https](https://www.springframework.org/schema/task/spring-task.xsd) result 200).
* http://www.springframework.org/schema/util/spring-util.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/util/spring-util.xsd ([https](https://www.springframework.org/schema/util/spring-util.xsd) result 200).
* http://docs.spring.io/spring-batch-admin/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch-admin/ ([https](https://docs.spring.io/spring-batch-admin/) result 301).
* http://static.springframework.org/spring-batch/apidocs/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/apidocs/ ([https](https://static.springframework.org/spring-batch/apidocs/) result 301).
* http://static.springframework.org/spring-batch/index.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch/index.html ([https](https://static.springframework.org/spring-batch/index.html) result 301).
* http://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/ ([https](https://jakarta.apache.org/commons/collections/apidocs-COLLECTIONS_3_0/) result 301).
* http://jakarta.apache.org/commons/dbcp/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/dbcp/apidocs/ ([https](https://jakarta.apache.org/commons/dbcp/apidocs/) result 301).
* http://jakarta.apache.org/commons/fileupload/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/fileupload/apidocs/ ([https](https://jakarta.apache.org/commons/fileupload/apidocs/) result 301).
* http://jakarta.apache.org/commons/httpclient/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/httpclient/apidocs/ ([https](https://jakarta.apache.org/commons/httpclient/apidocs/) result 301).
* http://jakarta.apache.org/commons/logging/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/logging/apidocs/ ([https](https://jakarta.apache.org/commons/logging/apidocs/) result 301).
* http://jakarta.apache.org/commons/pool/apidocs/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/commons/pool/apidocs/ ([https](https://jakarta.apache.org/commons/pool/apidocs/) result 301).
* http://jakarta.apache.org/velocity/api/ with 1 occurrences migrated to:  
  https://jakarta.apache.org/velocity/api/ ([https](https://jakarta.apache.org/velocity/api/) result 301).
* http://maven.apache.org/maven-v4_0_0.xsd with 6 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://docs.spring.io/spring-batch-admin with 1 occurrences migrated to:  
  https://docs.spring.io/spring-batch-admin ([https](https://docs.spring.io/spring-batch-admin) result 302).
* http://java.sun.com/j2ee/1.4/docs/api with 1 occurrences migrated to:  
  https://java.sun.com/j2ee/1.4/docs/api ([https](https://java.sun.com/j2ee/1.4/docs/api) result 302).
* http://java.sun.com/j2se/1.5.0/docs/api with 1 occurrences migrated to:  
  https://java.sun.com/j2se/1.5.0/docs/api ([https](https://java.sun.com/j2se/1.5.0/docs/api) result 302).
* http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd with 2 occurrences migrated to:  
  https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd ([https](https://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd) result 302).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/xml/ns/j2ee with 4 occurrences
* http://maven.apache.org/BOOK/1.0.0 with 2 occurrences
* http://maven.apache.org/DECORATION/1.0.0 with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 12 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/batch with 17 occurrences
* http://www.springframework.org/schema/beans with 104 occurrences
* http://www.springframework.org/schema/context with 18 occurrences
* http://www.springframework.org/schema/integration with 25 occurrences
* http://www.springframework.org/schema/integration/file with 4 occurrences
* http://www.springframework.org/schema/integration/http with 4 occurrences
* http://www.springframework.org/schema/integration/jmx with 2 occurrences
* http://www.springframework.org/schema/jdbc with 2 occurrences
* http://www.springframework.org/schema/mvc with 2 occurrences
* http://www.springframework.org/schema/p with 6 occurrences
* http://www.springframework.org/schema/task with 2 occurrences
* http://www.springframework.org/schema/util with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 55 occurrences
* http://xmlns.jcp.org/xml/ns/javaee with 2 occurrences