### PR TITLE
URL Cleanup

### DIFF
--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/CumulativeHistory.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/CumulativeHistory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/DetailedJobInfo.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/DetailedJobInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/DetailedJobInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/DetailedJobInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/FileInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/FileInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionHistory.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionHistory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionInfo.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobExecutionInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInfo.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInstanceInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/JobInstanceInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/NoSuchBatchJobException.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/NoSuchBatchJobException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/NoSuchBatchJobInstanceException.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/NoSuchBatchJobInstanceException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionHistory.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionHistory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionInfo.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgress.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgress.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgressInfo.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgressInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgressInfoResource.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepExecutionProgressInfoResource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepType.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/StepType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/ExitStatusJacksonMixIn.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/ExitStatusJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/ISO8601DateFormatWithMilliSeconds.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/ISO8601DateFormatWithMilliSeconds.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParameterJacksonDeserializer.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParameterJacksonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParameterJacksonMixIn.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParameterJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParametersExtractor.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParametersExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParametersJacksonMixIn.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/JobParametersJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/StepExecutionHistoryJacksonMixIn.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/StepExecutionHistoryJacksonMixIn.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/VariableTypeJackson2ObjectMapperFactoryBean.java
+++ b/spring-batch-admin-domain/src/main/java/org/springframework/batch/admin/domain/support/VariableTypeJackson2ObjectMapperFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/AbstractSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/AbstractSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/DetailedJobInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/DetailedJobInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/FileInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/FileInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobExecutionInfoResourceRunningJobSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobExecutionInfoResourceRunningJobSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobExecutionInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobExecutionInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobInstanceInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/JobInstanceInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/StepExecutionInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/StepExecutionInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/StepExecutionProgressInfoResourceSerializationTests.java
+++ b/spring-batch-admin-domain/src/test/java/org/springframework/batch/admin/domain/StepExecutionProgressInfoResourceSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/configuration/CompositeApplicationContextFactory.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/configuration/CompositeApplicationContextFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileParentDirectoryFilter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileParentDirectoryFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileToJobLaunchRequestAdapter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileToJobLaunchRequestAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileToResourceAdapter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/FileToResourceAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationRequest.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationRequestToResourceAdapter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationRequestToResourceAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationResourceLoader.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobConfigurationResourceLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobNameToJobRestartRequestAdapter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/JobNameToJobRestartRequestAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/LastJobParametersJobLaunchRequestEnhancer.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/LastJobParametersJobLaunchRequestEnhancer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/MultipartJobConfigurationRequest.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/MultipartJobConfigurationRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/StringToJobLaunchRequestAdapter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/integration/StringToJobLaunchRequestAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/BatchMBeanExporter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/BatchMBeanExporter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/JobExecutionMetrics.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/JobExecutionMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/JobExecutionMetricsFactory.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/JobExecutionMetricsFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/SimpleJobExecutionMetrics.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/SimpleJobExecutionMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/SimpleStepExecutionMetrics.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/SimpleStepExecutionMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionMetrics.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionMetrics.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionMetricsFactory.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionMetricsFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionServiceLevelMonitor.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/jmx/StepExecutionServiceLevelMonitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/launch/JobLauncherSynchronizer.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/launch/JobLauncherSynchronizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileInfo.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileSender.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileSender.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileServiceResourceConverter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/FileServiceResourceConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobInstanceDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableJobInstanceDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JobLocatorStepLocator.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JobLocatorStepLocator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JobService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/JobService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/LocalFileService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/NoSuchStepExecutionException.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/NoSuchStepExecutionException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableJobExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableJobExecutionDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableJobInstanceDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableJobInstanceDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableStepExecutionDao.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SearchableStepExecutionDao.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SimpleJobService.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SimpleJobService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SimpleJobServiceFactoryBean.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/service/SimpleJobServiceFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/util/ThrottledTaskExecutor.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/util/ThrottledTaskExecutor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/AbstractBatchJobsController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/AbstractBatchJobsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchFileController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchFileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobExecutionsController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobExecutionsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobInstancesController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobInstancesController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobsController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchJobsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchStepExecutionsController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BatchStepExecutionsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BindingHttpMessageConverter.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/BindingHttpMessageConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/ExecutionsMenu.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/ExecutionsMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/FileController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/FileController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/FilesMenu.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/FilesMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/HomeMenu.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/HomeMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobExecutionController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobExecutionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobInstanceInfo.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobInstanceInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobsMenu.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JobsMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JsonViewResolver.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/JsonViewResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/LaunchRequest.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/LaunchRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/RestConfiguration.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/RestConfiguration.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/RestControllerAdvice.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/RestControllerAdvice.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/StepExecutionController.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/StepExecutionController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/TableUtils.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/TableUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/ViewHandler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/ViewHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/DetailedJobInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/DetailedJobInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/FileInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/FileInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobExecutionInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobExecutionInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobInstanceInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/JobInstanceInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/StepExecutionInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/StepExecutionInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/StepExecutionProgressInfoResourceAssembler.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/admin/web/resource/StepExecutionProgressInfoResourceAssembler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/main/java/org/springframework/batch/poller/scheduling/TaskSchedulerPoller.java
+++ b/spring-batch-admin-manager/src/main/java/org/springframework/batch/poller/scheduling/TaskSchedulerPoller.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/BootstrapTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/BootstrapTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/IgnoredTestSuite.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/IgnoredTestSuite.java
@@ -13,7 +13,7 @@ import org.springframework.batch.admin.service.LocalFileServiceJobIntegrationTes
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/annotation/EnableBatchAdminTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/annotation/EnableBatchAdminTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/configuration/CompositeApplicationContextFactoryTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/configuration/CompositeApplicationContextFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/history/CumulativeHistoryTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/history/CumulativeHistoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/history/StepExecutionHistoryTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/history/StepExecutionHistoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobConfigurationRequestLoaderTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobConfigurationRequestLoaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobLaunchRequestFileAdapterTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobLaunchRequestFileAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobRestartRequestStringAdapterTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/JobRestartRequestStringAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/StringToJobLaunchRequestAdapterTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/integration/StringToJobLaunchRequestAdapterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterNoStepsIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterNoStepsIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/BatchMBeanExporterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/IntegrationAndBatchMBeanExporterIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/IntegrationAndBatchMBeanExporterIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/SimpleJobExecutionMetricsTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/jmx/SimpleJobExecutionMetricsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/launch/JobLauncherSynchronizerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/launch/JobLauncherSynchronizerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleItemReader.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleItemReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleItemWriter.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleTasklet.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/ExampleTasklet.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/FileDropJobIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/FileDropJobIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/JobConfigurationRequestIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/JobConfigurationRequestIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/JobLaunchIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/JobLaunchIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/LeadRandomizer.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/LeadRandomizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/RestartJobIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/RestartJobIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/StagingJobTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/StagingJobTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/StringPayloadJobIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/StringPayloadJobIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/TestMessagingGateway.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/TestMessagingGateway.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Client.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Client.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Lead.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Lead.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Product.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/Product.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/LeadFieldSetMapper.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/LeadFieldSetMapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/SimpleReader.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/SimpleReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/SimpleWriter.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/sample/lead/support/SimpleWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/ActiveProfileSuite.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/ActiveProfileSuite.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/FileInfoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/FileInfoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcDaoIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcDaoIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDaoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableJobExecutionDaoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableJobInstanceDaoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableJobInstanceDaoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDaoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JdbcSearchableStepExecutionDaoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobLocatorStepLocatorIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobLocatorStepLocatorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobLocatorStepLocatorTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobLocatorStepLocatorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobSupport.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/JobSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/SimpleJobServiceFactoryTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/SimpleJobServiceFactoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/SimpleJobServiceTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/service/SimpleJobServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/util/RegExpTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/util/RegExpTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/util/ThrottledTaskExecutorTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/util/ThrottledTaskExecutorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/AbstractControllerIntegrationTest.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/AbstractControllerIntegrationTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchFilesControllerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchFilesControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobExecutionsControllerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobExecutionsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobInstancesControllerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobInstancesControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobsControllerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchJobsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchStepExecutionsControllerIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/BatchStepExecutionsControllerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobControllerTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobExecutionControllerTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobExecutionControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobExecutionInfoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobExecutionInfoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobParametersExtractorTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JobParametersExtractorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JsonWrapper.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/JsonWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/MultiBinderTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/MultiBinderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionControllerTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionInfoTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionInfoTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionProgressTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/StepExecutionProgressTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/TestDependencies.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/TestDependencies.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/base/DummyMenu.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/base/DummyMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/resources/TestMenu.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/resources/TestMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/server/JsonIntegrationTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/server/JsonIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/AbstractManagerViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/AbstractManagerViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/ConfigurationViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/ConfigurationViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/FilesJsonViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/FilesJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/FilesViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/FilesViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionJsonViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsJsonViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsRssViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsRssViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobExecutionsViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobJsonViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/JobViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionHistoryViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionHistoryViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionJsonViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionsViewTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/admin/web/views/StepExecutionsViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/batch/poller/scheduling/TaskSchedulerPollerTests.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/batch/poller/scheduling/TaskSchedulerPollerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-manager/src/test/java/org/springframework/test/context/support/WebApplicationContextLoader.java
+++ b/spring-batch-admin-manager/src/test/java/org/springframework/test/context/support/WebApplicationContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/filter/ParameterUnpackerFilter.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/filter/ParameterUnpackerFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/filter/SessionIdFilter.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/filter/SessionIdFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/freemarker/AjaxFreeMarkerView.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/freemarker/AjaxFreeMarkerView.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/freemarker/HippyFreeMarkerConfigurer.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/freemarker/HippyFreeMarkerConfigurer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/interceptor/ContentTypeInterceptor.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/interceptor/ContentTypeInterceptor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/BaseMenu.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/BaseMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/DefaultResourceService.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/DefaultResourceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/Menu.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/Menu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/MenuManager.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/MenuManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/ResourceService.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/resources/ResourceService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/util/HomeController.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/util/HomeController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/util/ResourceInfo.java
+++ b/spring-batch-admin-resources/src/main/java/org/springframework/batch/admin/web/util/ResourceInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/filter/ParameterUnpackerFilterTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/filter/ParameterUnpackerFilterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/filter/SessionIdFilterTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/filter/SessionIdFilterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/interceptor/ContentTypeInterceptorTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/interceptor/ContentTypeInterceptorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/resources/DummyMenu.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/resources/DummyMenu.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/util/HomeControllerTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/util/HomeControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/AbstractResourceViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/AbstractResourceViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/HomeJsonViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/HomeJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/HomeViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/HomeViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/JsonWrapper.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/JsonWrapper.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/RssViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/RssViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/StandardJsonViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/StandardJsonViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/StandardViewTests.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/batch/admin/web/views/StandardViewTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-resources/src/test/java/org/springframework/test/context/support/WebApplicationContextLoader.java
+++ b/spring-batch-admin-resources/src/test/java/org/springframework/test/context/support/WebApplicationContextLoader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/ExampleItemReader.java
+++ b/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/ExampleItemReader.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/ExampleItemWriter.java
+++ b/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/ExampleItemWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/RemoteStep.java
+++ b/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/RemoteStep.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/TrivialJobParametersIncrementer.java
+++ b/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/TrivialJobParametersIncrementer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/job/JobConfiguration.java
+++ b/spring-batch-admin-sample/src/main/java/org/springframework/batch/admin/sample/job/JobConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/BootstrapTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/BootstrapTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/ExampleItemReaderTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/ExampleItemReaderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/ExampleItemWriterTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/ExampleItemWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/JobExecutionTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/JobExecutionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/JobIntegrationTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/JobIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/job/JobConfigurationTests.java
+++ b/spring-batch-admin-sample/src/test/java/org/springframework/batch/admin/sample/job/JobConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/assembly/license.txt
+++ b/src/assembly/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 222 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).